### PR TITLE
Some fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -410,6 +410,7 @@ class App extends React.Component<{}> {
         switch (displayRequest.method) {
           case "eth_sendTransaction":
             result = await sendTransaction(displayRequest.params[0]);
+            break;
           case "personal_sign":
           case "eth_sign":
             if (address.toLowerCase() === displayRequest.params[0].toLowerCase()) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -412,7 +412,7 @@ class App extends React.Component<{}> {
             result = await sendTransaction(displayRequest.params[0]);
           case "personal_sign":
           case "eth_sign":
-            if (address === displayRequest.params[0]) {
+            if (address.toLowerCase() === displayRequest.params[0].toLowerCase()) {
               result = await signMessage(displayRequest.params[1]);
             }
           default:

--- a/src/helpers/wallet.ts
+++ b/src/helpers/wallet.ts
@@ -30,12 +30,18 @@ export async function updateWallet(address: string, chainId: number) {
 
 export async function sendTransaction(transaction: any) {
   if (activeAccount) {
-    if (transaction.from && transaction.from !== activeAccount.address) {
+    if (transaction.from && transaction.from.toLowerCase() !== activeAccount.address.toLowerCase()) {
       console.error("Transaction request From doesn't match active account"); // tslint:disable-line
     }
 
     if (transaction.from) {
       delete transaction.from;
+    }
+
+    // ethers.js expects gasLimit instead
+    if ('gas' in transaction) {
+      transaction.gasLimit = transaction.gas;
+      delete transaction.gas;
     }
 
     const result = await activeAccount.sendTransaction(transaction);

--- a/src/helpers/wallet.ts
+++ b/src/helpers/wallet.ts
@@ -54,7 +54,7 @@ export async function sendTransaction(transaction: any) {
 
 export async function signMessage(message: any) {
   if (activeAccount) {
-    const result = await activeAccount.signMessage(message);
+    const result = await activeAccount.signMessage(message.substring(0, 2) === "0x" ? ethers.utils.arrayify(message) : message);
     return result;
   } else {
     console.error("No Active Account"); // tslint:disable-line


### PR DESCRIPTION
Ethers.js expects 'gasLimit', but web3 will generate a transaction with 'gas'
Ethers.js expects an array when signing hex encoded messages