### PR TITLE
fix: account/network switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -333,8 +333,8 @@ class App extends React.Component<{}> {
 
   public updateSession = async (sessionParams: { chainId?: number; activeIndex?: number }) => {
     const { connector, chainId, accounts, activeIndex } = this.state;
-    const newChainId = sessionParams.chainId || chainId;
-    const newActiveIndex = sessionParams.activeIndex || activeIndex;
+    const newChainId = sessionParams.chainId ?? chainId;
+    const newActiveIndex = sessionParams.activeIndex ?? activeIndex;
     const address = accounts[newActiveIndex];
     if (connector) {
       connector.updateSession({


### PR DESCRIPTION
fix the account (or network) switch bug:

when `activeIndex` ( or`chainId`) is `0` the variable `newActiveIndex` (or `newChainId`) is not set properly
